### PR TITLE
Faststream 0.6.0 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 
 dependencies = [
     "taskiq>=0.11.0,<0.12.0",
-    "faststream>=0.3.14,<0.6.0",
+    "faststream>=0.6.0rc0",
 ]
 
 [project.optional-dependencies]

--- a/taskiq_faststream/utils.py
+++ b/taskiq_faststream/utils.py
@@ -2,7 +2,7 @@ import typing
 
 from fast_depends.utils import is_async_gen_callable, is_gen_callable
 from faststream.types import SendableMessage
-from faststream.utils.functions import to_async
+from faststream._internal.utils.functions import to_async
 
 
 async def resolve_msg(

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -1,12 +1,12 @@
 import asyncio
 import typing
+import anyio
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Optional, ContextManager, Callable
 from unittest.mock import MagicMock
 
 import pytest
 from faststream.types import SendableMessage
-from faststream.utils.functions import timeout_scope
 from freezegun import freeze_time
 from taskiq import AsyncBroker
 from taskiq.cli.scheduler.args import SchedulerArgs
@@ -15,6 +15,16 @@ from taskiq.schedule_sources import LabelScheduleSource
 
 from taskiq_faststream import BrokerWrapper, StreamScheduler
 from tests import messages
+
+
+def timeout_scope(
+    timeout: Optional[float] = 30,
+    raise_timeout: bool = False,
+) -> ContextManager[anyio.CancelScope]:
+    scope: Callable[[Optional[float]], ContextManager[anyio.CancelScope]]
+    scope = anyio.fail_after if raise_timeout else anyio.move_on_after
+
+    return scope(timeout)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Faststream 0.6.0 support, restoring `timeout_scope` function from previous FS version.